### PR TITLE
Add import_optional to better handle p12 files that don't contain all…

### DIFF
--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "security-framework"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Security Framework bindings"


### PR DESCRIPTION
… identity items